### PR TITLE
Install ConfigArgParse 0.10.0 instead of latest

### DIFF
--- a/dependencies
+++ b/dependencies
@@ -21,7 +21,7 @@ pip install https://github.com/Theano/Theano/archive/master.zip
 pip install https://github.com/Lasagne/Lasagne/archive/master.zip
 
 echo 'Installing other Python module dependencies...'
-pip install ConfigArgParse 'pyhocon==0.3.18' pypng 'Protobuf>=3.0.0b2' scikit-learn scikit-image matplotlib
+pip install 'ConfigArgParse==0.10.0' 'pyhocon==0.3.18' pypng 'Protobuf>=3.0.0b2' scikit-learn scikit-image matplotlib
 
 if [ ! -e tensorflow ]; then
     echo 'Checking for tensorboard protos...'


### PR DESCRIPTION
With the latest version of ConfigArgParse (0.11.0 as of this writing), the API has changed, resulting in the following error when I try to run the `run_experiment.py` example:

```
Traceback (most recent call last):
  File "run_experiment.py", line 1, in <module>
    from stanza.research import config
  File "/Users/ryan/mess/2016/46/color-describer/stanza/research/config.py", line 65, in <module>
    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
TypeError: __init__() got an unexpected keyword argument 'config_file_parser'
```