### PR TITLE
Fix unexpected keyword argument in config.py

### DIFF
--- a/third-party/stanza/stanza/research/config.py
+++ b/third-party/stanza/stanza/research/config.py
@@ -61,7 +61,7 @@ class HoconConfigFileParser(object):
 
 
 _options_parser = ArgumentParser(conflict_handler='resolve', add_help=False,
-                                 config_file_parser=HoconConfigFileParser(),
+                                 config_file_parser_class=HoconConfigFileParser,
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 _options_parser.add_argument('--run_dir', '-R', type=str, default=None,
                              help='The directory in which to write log files, parameters, etc. '


### PR DESCRIPTION
This fixes the following problem:
```
>>> import colordesc
>>> describer = colordesc.ColorDescriber()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "colordesc.py", line 23, in __init__
    self.model = pickle.load(infile)
  File "speaker.py", line 15, in <module>
    from stanza.research import config, iterators, instance
  File "stanza/research/config.py", line 65, in <module>
    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
TypeError: __init__() got an unexpected keyword argument 'config_file_parser'
```
After this change:
```
>>> import colordesc
>>> describer = colordesc.ColorDescriber()
>>> describer.describe((255, 0, 0))
'red'
```